### PR TITLE
Fix `ParsedCompute` issues

### DIFF
--- a/src/tensor_computes/ParsedCompute.C
+++ b/src/tensor_computes/ParsedCompute.C
@@ -155,8 +155,6 @@ ParsedCompute::ParsedCompute(const InputParameters & parameters)
     const auto variables = MooseUtils::join(variables_vec, ",");
 
     // parse
-    fp.Parse(expression, variables);
-
     if (fp.Parse(expression, variables) >= 0)
       paramError("expression", "Invalid function: ", fp.ErrorMsg());
 

--- a/src/utils/ParsedJITTensor.C
+++ b/src/utils/ParsedJITTensor.C
@@ -447,6 +447,15 @@ ParsedJITTensor::setupTensors()
         s[sp] = _graph->insert(aten::pow, {s[sp], const_one_third});
         break;
 
+      case cHypot:
+        --sp;
+        s[sp] =
+            _graph->insert(aten::sqrt,
+                           {_graph->insert(aten::add,
+                                           {_graph->insert(aten::mul, {s[sp], s[sp]}),
+                                            _graph->insert(aten::mul, {s[sp + 1], s[sp + 1]})})});
+        break;
+
       case cFetch:
         ++sp;
         s[sp] = s[ByteCode[++i]];

--- a/src/utils/ParsedTensor.C
+++ b/src/utils/ParsedTensor.C
@@ -57,17 +57,11 @@ ParsedTensor::Eval(const std::vector<const torch::Tensor *> & params)
         break;
       case cAdd:
         --sp;
-        if (s[sp].sizes() == s[sp + 1].sizes())
-          s[sp] += s[sp + 1];
-        else
-          s[sp] = s[sp] + s[sp + 1];
+        s[sp] = s[sp] + s[sp + 1];
         break;
       case cSub:
         --sp;
-        if (s[sp].sizes() == s[sp + 1].sizes())
-          s[sp] -= s[sp + 1];
-        else
-          s[sp] = s[sp] - s[sp + 1];
+        s[sp] = s[sp] - s[sp + 1];
         break;
       case cRSub:
         --sp;
@@ -75,17 +69,11 @@ ParsedTensor::Eval(const std::vector<const torch::Tensor *> & params)
         break;
       case cMul:
         --sp;
-        if (s[sp].sizes() == s[sp + 1].sizes())
-          s[sp] *= s[sp + 1];
-        else
-          s[sp] = s[sp] * s[sp + 1];
+        s[sp] = s[sp] * s[sp + 1];
         break;
       case cDiv:
         --sp;
-        if (s[sp].sizes() == s[sp + 1].sizes())
-          s[sp] /= s[sp + 1];
-        else
-          s[sp] = s[sp] / s[sp + 1];
+        s[sp] = s[sp] / s[sp + 1];
         break;
       case cMod:
         --sp;


### PR DESCRIPTION
Add support for `cHypot` (hypothenuse operator) and remove in-place ops in non-JIT tensor that had erroneous side effects. Add unit test. @chaibhave 