### PR TITLE
Fix compile error with pytorch 2.7

### DIFF
--- a/src/tensor_computes/FFTQuasistaticElasticity.C
+++ b/src/tensor_computes/FFTQuasistaticElasticity.C
@@ -92,7 +92,7 @@ FFTQuasistaticElasticity::computeBuffer()
       {stack({Axx, Axy, Axz}, -1), stack({Axy, Ayy, Ayz}, -1), stack({Axz, Ayz, Azz}, -1)}, -1);
 
   // solve
-  const auto x = torch::linalg::solve(A, b, true);
+  const auto x = at::linalg_solve(A, b, true);
 
   // inverse transform the solution
   using torch::indexing::Slice;


### PR DESCRIPTION
In newer PyTorch versions the `namespache linalg` is gone, and we need to access the functions through `at::`.