### PR TITLE
Remove erroneous in-place operations

### DIFF
--- a/src/utils/ParsedTensor.C
+++ b/src/utils/ParsedTensor.C
@@ -248,10 +248,10 @@ ParsedTensor::Eval(const std::vector<const torch::Tensor *> & params)
         s[sp] = 1.0 / s[sp];
         break;
       case cDeg:
-        s[sp] *= 180.0 / libMesh::pi;
+        s[sp] = s[sp] * (180.0 / libMesh::pi);
         break;
       case cRad:
-        s[sp] /= 180.0 / libMesh::pi;
+        s[sp] = s[sp] / (180.0 / libMesh::pi);
         break;
 
       case cFetch:
@@ -306,7 +306,7 @@ ParsedTensor::Eval(const std::vector<const torch::Tensor *> & params)
 #endif
 
       case cSqr:
-        s[sp] *= s[sp];
+        s[sp] = s[sp] * s[sp];
         break;
       case cSqrt:
         s[sp] = torch::sqrt(s[sp]);


### PR DESCRIPTION
Remove in-place operations in `enable_jit = false` parsed computes. Those could lead to an expression of `x^2` modifying the real space axis for teh entire simulation. Bad!