### PR TITLE
Skip cpu copy for undefined tensors

### DIFF
--- a/src/tensor_buffers/NEML2TensorBuffer.C
+++ b/src/tensor_buffers/NEML2TensorBuffer.C
@@ -39,6 +39,9 @@ template <typename T>
 void
 NEML2TensorBuffer<T>::makeCPUCopy()
 {
+  if (!_u.defined())
+    return;
+
   if (_cpu_copy_requested)
   {
     if (_u.is_cpu())

--- a/src/tensor_buffers/PlainTensorBuffer.C
+++ b/src/tensor_buffers/PlainTensorBuffer.C
@@ -32,6 +32,9 @@ PlainTensorBuffer::init()
 void
 PlainTensorBuffer::makeCPUCopy()
 {
+  if (!_u.defined())
+    return;
+
   if (_cpu_copy_requested)
   {
     if (_u.is_cpu())


### PR DESCRIPTION
We'd like to simply skip output on undefined tensors rather than throwing a `tensor has no device` exception. Such a check is already made in `XDMFTensorOutput` but a recently removed try/catch in the tensor classes' `makeCPUCopy` reintroduced the exception. 

Explicitly check for `defined()` rather than catching all exceptions.