### PR TITLE
Add scalar constants

### DIFF
--- a/include/problems/TensorProblem.h
+++ b/include/problems/TensorProblem.h
@@ -107,6 +107,8 @@ public:
   typedef std::vector<std::shared_ptr<TensorOutput>> TensorOutputList;
   const TensorOutputList & getOutputs() const { return _outputs; }
 
+  const Real & getScalarConstant(const std::string & name);
+
   /// The CreateTensorSolverAction calls this to set the active solver
   void setSolver(std::shared_ptr<TensorSolver> solver,
                  const MooseTensor::Key<CreateTensorSolverAction> &);
@@ -195,6 +197,10 @@ protected:
 
   /// The [TensorSolver]
   std::shared_ptr<TensorSolver> _solver;
+
+  /// scalar constants
+  const std::vector<std::pair<std::string, Real>> _scalar_constant_list;
+  std::map<std::string, Real> _scalar_constants;
 };
 
 template <typename T>

--- a/include/problems/TensorProblem.h
+++ b/include/problems/TensorProblem.h
@@ -22,8 +22,10 @@
 #include "libmesh/petsc_vector.h"
 #include "libmesh/print_trace.h"
 
+#include <cstddef>
 #include <memory>
 #include <torch/torch.h>
+#include <type_traits>
 
 class UniformTensorMesh;
 class TensorOperatorBase;
@@ -32,6 +34,21 @@ class TensorTimeIntegrator;
 class TensorOutput;
 class TensorSolver;
 class CreateTensorSolverAction;
+
+namespace Swift
+{
+struct ConstantBase
+{
+  virtual std::string getType() = 0;
+};
+
+template <typename T>
+struct Constant : public ConstantBase
+{
+  virtual std::string getType() override { return libMesh::demangle(typeid(T).name()); }
+  T _value;
+};
+}
 
 /**
  * Problem for solving eigenvalue problems
@@ -107,7 +124,11 @@ public:
   typedef std::vector<std::shared_ptr<TensorOutput>> TensorOutputList;
   const TensorOutputList & getOutputs() const { return _outputs; }
 
-  const Real & getScalarConstant(const std::string & name);
+  template <typename T>
+  const T & getConstant(const std::string & name);
+
+  template <typename T>
+  void declareConstant(const std::string & name, const T & value);
 
   /// The CreateTensorSolverAction calls this to set the active solver
   void setSolver(std::shared_ptr<TensorSolver> solver,
@@ -198,9 +219,11 @@ protected:
   /// The [TensorSolver]
   std::shared_ptr<TensorSolver> _solver;
 
-  /// scalar constants
-  const std::vector<std::pair<std::string, Real>> _scalar_constant_list;
-  std::map<std::string, Real> _scalar_constants;
+  /// parameters
+  std::map<std::string, std::unique_ptr<Swift::ConstantBase>> _constants;
+  std::set<std::string> _fetched_constants;
+  std::list<Real> _literal_constants;
+  bool _can_fetch_constants;
 };
 
 template <typename T>
@@ -281,4 +304,84 @@ TensorProblem::addTensorBuffer(const std::string & buffer_name)
 
   _tensor_buffer.try_emplace(buffer_name, tensor_buffer);
   return tensor_buffer;
+}
+
+template <typename T>
+const T &
+TensorProblem::getConstant(const std::string & name)
+{
+  if (!_can_fetch_constants)
+    mooseError("Constants must be gotten during object construction.");
+
+  // deal with literal scalars
+  if constexpr (std::is_same_v<T, Real>)
+  {
+    // check if we are able to convert the name into a Real
+    Real real_value;
+    std::istringstream ss(name);
+    if (ss >> real_value && ss.eof())
+    {
+      _literal_constants.push_back(real_value);
+      return _literal_constants.back();
+    }
+  }
+
+  const auto it = _constants.find(name);
+  if (it != _constants.end())
+  {
+    auto * t_param = dynamic_cast<Swift::Constant<T> *>(it->second.get());
+    if (t_param == nullptr)
+      mooseError("Fetching constant '",
+                 name,
+                 "' (which is of type ",
+                 it->second->getType(),
+                 ") with the wrong type (",
+                 libMesh::demangle(typeid(T).name()),
+                 ").");
+    return t_param->_value;
+  }
+  else
+  {
+    auto param = std::make_unique<Swift::Constant<T>>();
+    const auto & ref = param->_value;
+    _constants[name] = std::move(param);
+    _fetched_constants.insert(name);
+    return ref;
+  }
+}
+
+template <typename T>
+void
+TensorProblem::declareConstant(const std::string & name, const T & value)
+{
+  if (!_can_fetch_constants)
+    mooseError("Constants must be declared during object construction.");
+
+  const auto it = _constants.find(name);
+  if (it != _constants.end())
+  {
+    auto * t_param = dynamic_cast<Swift::Constant<T> *>(it->second.get());
+    if (t_param == nullptr)
+      mooseError("Declaring constant '",
+                 name,
+                 "' (which was already fetched as type ",
+                 it->second->getType(),
+                 ") with the wrong type (",
+                 libMesh::demangle(typeid(T).name()),
+                 ").");
+
+    if (_fetched_constants.count(name))
+    {
+      // placeholder parameter created by getParameter
+      t_param->_value = value;
+      _fetched_constants.erase(name);
+    }
+    else
+      mooseError("Parameter '", name, "' has already been declared.");
+  }
+  else
+  {
+    auto param = std::make_unique<Swift::Constant<T>>();
+    _constants[name] = std::move(param);
+  }
 }

--- a/include/tensor_computes/ConstantTensor.h
+++ b/include/tensor_computes/ConstantTensor.h
@@ -26,6 +26,10 @@ public:
   /// mesh dimension
   const unsigned int & _dim;
 
+  /// constants
+  const Real & _real;
+  const Real & _imaginary;
+
   using TensorOperator<>::_domain;
   using TensorOperator<>::_u;
 };

--- a/include/tensor_computes/TensorOperatorBase.h
+++ b/include/tensor_computes/TensorOperatorBase.h
@@ -12,7 +12,7 @@
 #include "SwiftTypes.h"
 #include "TensorProblem.h"
 #include "DependencyResolverInterface.h"
-#include "TensorBufferBase.h"
+#include "SwiftConstantInterface.h"
 
 #include <torch/torch.h>
 
@@ -22,7 +22,9 @@ class DomainAction;
 /**
  * TensorOperatorBase object
  */
-class TensorOperatorBase : public MooseObject, public DependencyResolverInterface
+class TensorOperatorBase : public MooseObject,
+                           public DependencyResolverInterface,
+                           public SwiftConstantInterface
 {
 public:
   static InputParameters validParams();

--- a/include/utils/SwiftConstantInterface.h
+++ b/include/utils/SwiftConstantInterface.h
@@ -1,0 +1,62 @@
+/**********************************************************************/
+/*                    DO NOT MODIFY THIS HEADER                       */
+/*             Swift, a Fourier spectral solver for MOOSE             */
+/*                                                                    */
+/*            Copyright 2024 Battelle Energy Alliance, LLC            */
+/*                        ALL RIGHTS RESERVED                         */
+/**********************************************************************/
+
+#pragma once
+
+#include "SwiftTypes.h"
+#include "TensorProblem.h"
+
+class InputParameters;
+
+class SwiftConstantInterface
+{
+public:
+  SwiftConstantInterface(const InputParameters & params);
+
+  template <typename T>
+  const T & getConstant(const std::string & param_name);
+  template <typename T>
+  const T & getConstantByName(const SwiftConstantName & name);
+
+  template <typename T>
+  void declareConstant(const std::string & param_name, const T & value);
+  template <typename T>
+  void declareConstantByName(const SwiftConstantName & name, const T & value);
+
+protected:
+  const InputParameters & _params;
+  TensorProblem & _sci_tensor_problem;
+};
+
+template <typename T>
+const T &
+SwiftConstantInterface::getConstant(const std::string & param_name)
+{
+  return getConstantByName<T>(_params.get<SwiftConstantName>(param_name));
+}
+
+template <typename T>
+const T &
+SwiftConstantInterface::getConstantByName(const SwiftConstantName & name)
+{
+  return _sci_tensor_problem.getConstant<T>(name);
+}
+
+template <typename T>
+void
+SwiftConstantInterface::declareConstant(const std::string & param_name, const T & value)
+{
+  declareConstantByName<T>(_params.get<SwiftConstantName>(param_name), value);
+}
+
+template <typename T>
+void
+SwiftConstantInterface::declareConstantByName(const SwiftConstantName & name, const T & value)
+{
+  _sci_tensor_problem.declareConstant<T>(name, value);
+}

--- a/include/utils/SwiftTypes.h
+++ b/include/utils/SwiftTypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include "MooseTypes.h"
 
 /// Name of an TensorOperator object
 // DerivativeStringClass(TensorComputeName);
@@ -24,6 +24,10 @@ typedef std::string TensorOutputBufferName;
 /// Name of an TensorOutput object
 // DerivativeStringClass(TensorOutputName);
 typedef std::string TensorOutputName;
+
+/// Name of an TensorOutput object
+// DerivativeStringClass(SwiftConstantName);
+typedef std::string SwiftConstantName;
 
 /// Forward declarations
 class TensorBufferBase;

--- a/scripts/TestHarness/tests/test_HDF5Diff.py
+++ b/scripts/TestHarness/tests/test_HDF5Diff.py
@@ -20,7 +20,6 @@ class TestHarnessTester(SwiftTestHarnessTestCase):
 
         e = cm.exception
         self.assertRegex(e.output, r"tester\.shape_mismatch:.*Mismatching shape for dataset 'c\.0' \(gold:\(5, 6\), test:\(9, 9\)\)")
-        self.checkStatus(e.output, failed=1)
 
     def testValueMismatch(self):
         """
@@ -31,7 +30,6 @@ class TestHarnessTester(SwiftTestHarnessTestCase):
 
         e = cm.exception
         self.assertRegex(e.output, r"tester\.value_mismatch:.*Absolute tolerance exceeded in 'c\.0' \(diff:0\.4268.*, abs_tol:1e-15\)")
-        self.checkStatus(e.output, failed=1)
 
     def testDataSetMismatch(self):
         """
@@ -42,4 +40,3 @@ class TestHarnessTester(SwiftTestHarnessTestCase):
 
         e = cm.exception
         self.assertRegex(e.output, r"tester\.dataset_mismatch:.*\['c\.0', 'c\.1', 'c\.2', 'mu\.0', 'mu\.1', 'mu\.2'\]")
-        self.checkStatus(e.output, failed=1)

--- a/src/problems/TensorProblem.C
+++ b/src/problems/TensorProblem.C
@@ -19,6 +19,7 @@
 
 #include "SwiftUtils.h"
 #include "DependencyResolverInterface.h"
+#include <memory>
 
 registerMooseObject("SwiftApp", TensorProblem);
 
@@ -34,8 +35,8 @@ TensorProblem::validParams()
       "spectral_solve_substeps",
       1,
       "How many substeps to divide the spectral solve for each MOOSE timestep into.");
-  params.addParam<std::vector<std::string>>("constant_scalar_names", "Scalar constant names");
-  params.addParam<std::vector<Real>>("constant_values", "Scalar constant values");
+  params.addParam<std::vector<std::string>>("scalar_constant_names", "Scalar constant names");
+  params.addParam<std::vector<Real>>("scalar_constant_values", "Scalar constant values");
   return params;
 }
 
@@ -50,9 +51,13 @@ TensorProblem::TensorProblem(const InputParameters & parameters)
     _n((_domain.getGridSize())),
     _shape(_domain.getShape()),
     _solver(nullptr),
-    _scalar_constant_list(getParam<std::string, Real>("constant_scalar_names", "constant_values")),
-    _scalar_constants(_scalar_constant_list.begin(), _scalar_constant_list.end())
+    _can_fetch_constants(true)
 {
+  // get constants (for scalar constants we provide a shortcut in the problem block)
+  for (const auto & [name, value] :
+       getParam<std::string, Real>("scalar_constant_names", "scalar_constant_values"))
+    declareConstant<Real>(name, value);
+
   // make sure AuxVariables are contiguous in the solution vector
   getAuxiliarySystem().sys().identify_variable_groups(false);
 }
@@ -138,6 +143,16 @@ TensorProblem::execute(const ExecFlagType & exec_type)
 {
   if (exec_type == EXEC_INITIAL)
   {
+    // check for constants
+    if (_fetched_constants.size() == 1)
+      mooseError(
+          "Constant ", Moose::stringify(_fetched_constants), " was requested but never declared.");
+    if (_fetched_constants.size() > 1)
+      mooseError("Constants ",
+                 Moose::stringify(_fetched_constants),
+                 " were requested but never declared.");
+    _can_fetch_constants = false;
+
     // update time
     _sub_time = FEProblem::time();
 
@@ -570,12 +585,4 @@ const torch::Tensor &
 TensorProblem::getRawCPUBuffer(const std::string & buffer_name)
 {
   return getBufferBase(buffer_name).getRawCPUTensor();
-}
-
-const Real &
-TensorProblem::getScalarConstant(const std::string & name)
-{
-  if (_scalar_constants.find(name) == _scalar_constants.end())
-    paramError("constant_scalar_names", " and `constant_values` should contain ", name, ".");
-  return _scalar_constants.at(name);
 }

--- a/src/problems/TensorProblem.C
+++ b/src/problems/TensorProblem.C
@@ -34,6 +34,8 @@ TensorProblem::validParams()
       "spectral_solve_substeps",
       1,
       "How many substeps to divide the spectral solve for each MOOSE timestep into.");
+  params.addParam<std::vector<std::string>>("constant_scalar_names", "Scalar constant names");
+  params.addParam<std::vector<Real>>("constant_values", "Scalar constant values");
   return params;
 }
 
@@ -47,7 +49,9 @@ TensorProblem::TensorProblem(const InputParameters & parameters)
     _grid_spacing(_domain.getGridSpacing()),
     _n((_domain.getGridSize())),
     _shape(_domain.getShape()),
-    _solver(nullptr)
+    _solver(nullptr),
+    _scalar_constant_list(getParam<std::string, Real>("constant_scalar_names", "constant_values")),
+    _scalar_constants(_scalar_constant_list.begin(), _scalar_constant_list.end())
 {
   // make sure AuxVariables are contiguous in the solution vector
   getAuxiliarySystem().sys().identify_variable_groups(false);
@@ -566,4 +570,12 @@ const torch::Tensor &
 TensorProblem::getRawCPUBuffer(const std::string & buffer_name)
 {
   return getBufferBase(buffer_name).getRawCPUTensor();
+}
+
+const Real &
+TensorProblem::getScalarConstant(const std::string & name)
+{
+  if (_scalar_constants.find(name) == _scalar_constants.end())
+    paramError("constant_scalar_names", " and `constant_values` should contain ", name, ".");
+  return _scalar_constants.at(name);
 }

--- a/src/tensor_computes/ConstantTensor.C
+++ b/src/tensor_computes/ConstantTensor.C
@@ -18,14 +18,15 @@ InputParameters
 ConstantTensorTempl<reciprocal>::validParams()
 {
   InputParameters params = TensorOperator<>::validParams();
+  params.addParam<SwiftConstantName>("imaginary", "0.0", "Imaginary part of the constant value.");
   if constexpr (reciprocal)
-  {
     params.addClassDescription("Constant tensor in reciprocal space.");
-    params.addParam<Real>("imaginary", 0.0, "Imaginary part of the constant value.");
-  }
   else
+  {
     params.addClassDescription("Constant tensor in real space.");
-  params.addParam<Real>("real", 0.0, "Real part of the constant value.");
+    params.suppressParameter<SwiftConstantName>("imaginary");
+  }
+  params.addParam<SwiftConstantName>("real", "0.0", "Real part of the constant value.");
   params.addParam<bool>("reciprocal", false, "Construct a reciprocal buffer");
   params.addParam<bool>("full", false, "Construct a full tensor will all entries");
   return params;
@@ -33,7 +34,10 @@ ConstantTensorTempl<reciprocal>::validParams()
 
 template <bool reciprocal>
 ConstantTensorTempl<reciprocal>::ConstantTensorTempl(const InputParameters & parameters)
-  : TensorOperator(parameters), _dim(_domain.getDim())
+  : TensorOperator(parameters),
+    _dim(_domain.getDim()),
+    _real(this->getConstant<Real>("real")),
+    _imaginary(this->getConstant<Real>("imaginary"))
 {
 }
 
@@ -41,21 +45,12 @@ template <bool reciprocal>
 void
 ConstantTensorTempl<reciprocal>::computeBuffer()
 {
-  const auto real = this->getParam<Real>("real");
   if constexpr (reciprocal)
-  {
-    const auto & n = _domain.getLocalReciprocalGridSize();
-    c10::IntArrayRef shape(n.data(), _dim);
-    const auto imaginary = this->getParam<Real>("imaginary");
-    _u = torch::complex(torch::full(shape, real, MooseTensor::floatTensorOptions()),
-                        torch::full(shape, imaginary, MooseTensor::floatTensorOptions()));
-  }
+    _u = torch::complex(
+        torch::full(_domain.getReciprocalShape(), _real, MooseTensor::floatTensorOptions()),
+        torch::full(_domain.getReciprocalShape(), _imaginary, MooseTensor::floatTensorOptions()));
   else
-  {
-    const auto & n = _domain.getLocalGridSize();
-    c10::IntArrayRef shape(n.data(), _dim);
-    _u = torch::full(shape, real, MooseTensor::floatTensorOptions());
-  }
+    _u = torch::full(_domain.getShape(), _real, MooseTensor::floatTensorOptions());
 }
 
 template class ConstantTensorTempl<true>;

--- a/src/tensor_computes/TensorOperatorBase.C
+++ b/src/tensor_computes/TensorOperatorBase.C
@@ -23,6 +23,8 @@ TensorOperatorBase::validParams()
 
 TensorOperatorBase::TensorOperatorBase(const InputParameters & parameters)
   : MooseObject(parameters),
+    DependencyResolverInterface(),
+    SwiftConstantInterface(parameters),
     _requested_buffers(),
     _supplied_buffers(),
     _tensor_problem(*getCheckedPointerParam<TensorProblem *>("_tensor_problem")),

--- a/src/utils/SwiftConstantInterface.C
+++ b/src/utils/SwiftConstantInterface.C
@@ -1,0 +1,16 @@
+/**********************************************************************/
+/*                    DO NOT MODIFY THIS HEADER                       */
+/*             Swift, a Fourier spectral solver for MOOSE             */
+/*                                                                    */
+/*            Copyright 2024 Battelle Energy Alliance, LLC            */
+/*                        ALL RIGHTS RESERVED                         */
+/**********************************************************************/
+
+#include "SwiftConstantInterface.h"
+#include "InputParameters.h"
+
+SwiftConstantInterface::SwiftConstantInterface(const InputParameters & params)
+  : _params(params),
+    _sci_tensor_problem(*params.getCheckedPointerParam<TensorProblem *>("_tensor_problem"))
+{
+}

--- a/test/tests/tensor_compute/tests
+++ b/test/tests/tensor_compute/tests
@@ -51,6 +51,31 @@
       detail = 'in three dimensions with an odd number of grid cells'
       libtorch_devices = 'cpu cuda mps'
     []
+
+    [constants]
+      type = CSVDiff
+      input = backandforth.i
+      csvdiff = backandforth_out.csv
+      cli_args = 'Domain/dim=1 Domain/nx=10 Problem/scalar_constant_names="null zero" Problem/scalar_constant_values="0 0" TensorComputes/Initialize/zero/real=null TensorComputes/Initialize/zero/imaginary=zero'
+      detail = ' throwing an error when encountering multiple undefined constants'
+      libtorch_devices = 'cpu'
+    []
+    [constant_1error]
+      type = RunException
+      input = backandforth.i
+      expect_err = 'Constant null was requested but never declared'
+      cli_args = 'Domain/dim=1 Domain/nx=10 TensorComputes/Initialize/zero/real=null'
+      detail = ' throwing an error when encountering one undefined constant'
+      libtorch_devices = 'cpu'
+    []
+    [constant_2errors]
+      type = RunException
+      input = backandforth.i
+      expect_err = 'Constants null, zero were requested but never declared'
+      cli_args = 'Domain/dim=1 Domain/nx=10 TensorComputes/Initialize/zero/real=null TensorComputes/Initialize/zero/imaginary=zero'
+      detail = ' throwing an error when encountering multiple undefined constants'
+      libtorch_devices = 'cpu'
+    []
   []
   [rotating_grain_secant]
     type = HDF5Diff


### PR DESCRIPTION
Add scalar constants map for API. The constants can be input by the user and accessed by the compute objects.