### PR TITLE
add option to build binary media in initialization phase

### DIFF
--- a/examples/lbm/Pebbles/pebbles.i
+++ b/examples/lbm/Pebbles/pebbles.i
@@ -332,7 +332,7 @@
       type = LBMDirichletWallBC
       buffer = g
       f_old = gpc
-      value = T_H
+      value = 1.2
       velocity = velocity
       boundary = wall
     []

--- a/include/tensor_computes/LBMDirichletWallBC.h
+++ b/include/tensor_computes/LBMDirichletWallBC.h
@@ -40,5 +40,7 @@ protected:
   torch::Tensor _e_xyz;
 
   const torch::Tensor _velocity;
-  const Real & _value;
+  bool _is_value_tensor;
+  torch::Tensor _value_tensor;
+  Real _value;
 };

--- a/src/problems/LatticeBoltzmannProblem.C
+++ b/src/problems/LatticeBoltzmannProblem.C
@@ -98,6 +98,13 @@ LatticeBoltzmannProblem::execute(const ExecFlagType & exec_type)
 
     executeTensorInitialConditions();
 
+    // if the binary mesh is updated at initial conditions
+    // in the future we need a better way to handle this
+    if (_is_binary_media)
+      _binary_media = getBuffer(getParam<TensorInputBufferName>("binary_media"));
+    else
+      _binary_media = torch::ones(_shape, MooseTensor::intTensorOptions());
+
     executeTensorOutputs(EXEC_INITIAL);
   }
 
@@ -158,7 +165,7 @@ void
 LatticeBoltzmannProblem::maskedFillSolids(torch::Tensor & t, const Real & value)
 {
   const auto tensor_shape = t.sizes();
-  if (_is_binary_media)
+  if (_is_binary_media && _binary_media.sum().item<int64_t>() > 0)
   {
     if (t.dim() == _binary_media.dim())
     {

--- a/src/problems/TensorProblem.C
+++ b/src/problems/TensorProblem.C
@@ -571,7 +571,7 @@ TensorProblem::addTensorOutput(const std::string & output_type,
 
   // Create the object
   auto output_object = _factory.create<TensorOutput>(output_type, output_name, parameters, 0);
-  logAdd("TensorInitialCondition", output_name, output_type, parameters);
+  logAdd("TensorOutput", output_name, output_type, parameters);
   _outputs.push_back(output_object);
 }
 

--- a/test/tests/lbm/advan_bc.i
+++ b/test/tests/lbm/advan_bc.i
@@ -308,7 +308,7 @@
       type = LBMDirichletWallBC
       buffer = g
       f_old = gpc
-      value = T_H
+      value = 1.2
       velocity = velocity
       boundary = wall
     []


### PR DESCRIPTION
When `binary_media` is generated in  `[TensorComputes/Initialize]` it causes other buffers to completely go to zero. This is because, although binary_media is defined in the `[TensorBuffers]` the problem object does not have the initialized copy at the time of initializing other buffers. 

This PR prevents compute objects from filling the tensors in `LatticeBoltzmannProblem::maskedFillSolids`

Another feature this PR introduces is the ability to pass tensor buffers to Dirichlet wall boundary condition object.