### PR TITLE
Fix dependent template disambiguation for item<int64_t>()

### DIFF
--- a/src/tensor_computes/LBMCollisionDynamics.C
+++ b/src/tensor_computes/LBMCollisionDynamics.C
@@ -192,7 +192,7 @@ LBMCollisionDynamicsTempl<coll_dyn>::computeLocalRelaxationMatrix()
 
   for (int64_t sh_id = 0; sh_id < _stencil._id_kinematic_visc.size(0); sh_id++)
   {
-    int64_t idx = _stencil._id_kinematic_visc[sh_id].item<int64_t>();
+    int64_t idx = _stencil._id_kinematic_visc[sh_id].template item<int64_t>();
 
     // Zero-overhead assignment replacing index_put_
     // select(2, idx) gets [N, Q], select(1, idx) gets [N]


### PR DESCRIPTION
Current branch does not compile properly on my macOS Tahoe 26.4. It throws the error

```
In file included from /Users/bhavcv/projects/marlin/build/unity_src/tensor_computes_Unity.C:21:
/Users/bhavcv/projects/marlin/src/tensor_computes/LBMCollisionDynamics.C:195:54: error: use 'template' keyword to treat 'item' as a dependent template name
  195 |     int64_t idx = _stencil._id_kinematic_visc[sh_id].item<int64_t>();
      |                                                      ^
      |                                                      template 
Compiling C++ (in opt mode) /Users/bhavcv/projects/marlin/test/src/base/MarlinTestApp.C...
```
 
 Fix: Disambiguate dependent template call by adding `template` keyword:
`.template item<int64_t>()`.