### PR TITLE
Fix SR boundary error

### DIFF
--- a/src/tensor_computes/LBMBoundaryCondition.C
+++ b/src/tensor_computes/LBMBoundaryCondition.C
@@ -89,6 +89,9 @@ LBMBoundaryCondition::isBoundaryOwned(const int & value)
   if (!_lb_problem.isBinaryMedia())
     return false;
 
+  if (_binary_mesh.sum().item<long>() == 0)
+    return false;
+
   return torch::any(_binary_mesh == value).item<bool>();
 }
 


### PR DESCRIPTION
This PR fixes an error that occurs at large MPI rank counts, where some ranks fail unexpectedly.