### PR TITLE
Fix parmetis capability parsing error

### DIFF
--- a/doc/content/installation.md
+++ b/doc/content/installation.md
@@ -111,7 +111,7 @@ Now build Marlin with custom `LDFLAGS` to ensure that the torch libraries are fo
 
 ```
 cd ..
-make CXXFLAGS="-fiopenmp" LDFLAGS="-fiopenmp -lintel-ext-pt-gpu -Wl,--disable-new-dtags -Wl,-rpath,${INTEL_TORCH}/lib -L${INTEL_TORCH}/lib -Wl,-rpath,${LIBTORCH_DIR}/lib" -j32
+make CXXFLAGS="-fiopenmp -DPETSC_PKG_PARMETIS_VERSION_MAJOR=4 -DPETSC_PKG_PARMETIS_VERSION_MINOR=0 -DPETSC_PKG_PARMETIS_VERSION_SUBMINOR=3" LDFLAGS="-fiopenmp -lintel-ext-pt-gpu -Wl,--disable-new-dtags -Wl,-rpath,${INTEL_TORCH}/lib -L${INTEL_TORCH}/lib -Wl,-rpath,${LIBTORCH_DIR}/lib" -j32
 ```
 
 To run the code make sure each time your environment in `MARLIN_DIR` is set up with


### PR DESCRIPTION
On Aurora, tests cannot be run because of parsing issues. 
I keep getting this error.

`*** ERROR ***
String capability 'parmetis': value 'PETSC_PKG_PARMETIS_VERSION_MAJOR.PETSC_PKG_PARMETIS_VERSION_MINOR.PETSC_PKG_PARMETIS_VERSION_SUBMINOR' has unallowed characters; allowed characters = 'a-z, 0-9, _, ., -'`

@dschwen could you please look into it and let me know if this is the right fix? Although this worked but I am not 100% sure.