### PR TITLE
Patch for neml2 v2 removal of labeled axis

### DIFF
--- a/include/tensor_computes/NEML2TensorCompute.h
+++ b/include/tensor_computes/NEML2TensorCompute.h
@@ -11,7 +11,6 @@
 #include "TensorOperatorBase.h"
 
 #ifdef NEML2_ENABLED
-#include "neml2/base/LabeledAxisAccessor.h"
 #include "neml2/models/Model.h"
 #endif
 
@@ -35,7 +34,7 @@ protected:
 #ifdef NEML2_ENABLED
   std::shared_ptr<neml2::Model> _model;
 
-  std::vector<std::pair<const torch::Tensor *, neml2::LabeledAxisAccessor>> _input_mapping;
-  std::vector<std::pair<neml2::LabeledAxisAccessor, torch::Tensor *>> _output_mapping;
+  std::vector<std::pair<const torch::Tensor *, neml2::VariableName>> _input_mapping;
+  std::vector<std::pair<neml2::VariableName, torch::Tensor *>> _output_mapping;
 #endif
 };

--- a/src/tensor_computes/NEML2TensorCompute.C
+++ b/src/tensor_computes/NEML2TensorCompute.C
@@ -13,7 +13,6 @@
 
 #ifdef NEML2_ENABLED
 #include "neml2/neml2.h"
-#include "neml2/models/map_types_fwd.h"
 #include "neml2/tensors/Scalar.h"
 #include "neml2/tensors/Vec.h"
 #include "neml2/tensors/R2.h"
@@ -71,17 +70,14 @@ NEML2TensorCompute::NEML2TensorCompute(const InputParameters & params)
        getParam<TensorInputBufferName, std::string>("marlin_inputs", "neml2_inputs"))
   {
     const auto * input_buffer = &getInputBufferByName<>(marlin_input_name);
-    _input_mapping.emplace_back(
-        input_buffer, neml2::LabeledAxisAccessor(NEML2Utils::parseVariableName(neml2_input_name)));
+    _input_mapping.emplace_back(input_buffer, neml2_input_name);
   }
 
   for (const auto & [neml2_output_name, marlin_output_name] :
        getParam<std::string, TensorInputBufferName>("neml2_outputs", "marlin_outputs"))
   {
     auto * output_buffer = &getOutputBufferByName<>(marlin_output_name);
-    _output_mapping.emplace_back(
-        neml2::LabeledAxisAccessor(NEML2Utils::parseVariableName(neml2_output_name)),
-        output_buffer);
+    _output_mapping.emplace_back(neml2_output_name, output_buffer);
   }
 #endif
 }

--- a/test/tests/neml2/neml2_input.i
+++ b/test/tests/neml2/neml2_input.i
@@ -5,8 +5,8 @@
 [Models]
   [multiply]
     type = ScalarMultiplication
-    from_var = 'forces/A forces/B'
-    to_var = 'state/C'
+    from = 'A B'
+    to = 'C'
   []
 []
 

--- a/test/tests/neml2/scalar.i
+++ b/test/tests/neml2/scalar.i
@@ -29,8 +29,8 @@
       neml2_input_file = neml2_input.i
       neml2_model = multiply
       marlin_inputs = 'A B'
-      neml2_inputs = 'forces/A forces/B'
-      neml2_outputs = 'state/C'
+      neml2_inputs = 'A B'
+      neml2_outputs = 'C'
       marlin_outputs = 'C'
     []
   []


### PR DESCRIPTION
neml2 v2.1 removes the concept of labeled axis to simplify model definition. Some headers were dropped without backward compatibility. This PR patches marlin by removing the stale headers from neml2. tests/neml2/scalar.i removes the neml2 labeled axis to demonstrate the improvement.

Proudly shipped without the help of AI.

close #174